### PR TITLE
fix: absences résumé button always disabled + otel guard

### DIFF
--- a/actions/Achievements.ts
+++ b/actions/Achievements.ts
@@ -116,7 +116,7 @@ export async function checkAndUnlockAchievements() {
 
 		const posthog = PostHogClient();
 		newUnlocks.forEach((code) => {
-			posthog.capture({
+			posthog?.capture({
 				distinctId: user.username,
 				event: "achievement_unlocked",
 				properties: {
@@ -124,7 +124,7 @@ export async function checkAndUnlockAchievements() {
 				},
 			});
 		});
-		await posthog.shutdown();
+		await posthog?.shutdown();
 
 		revalidatePath("/achievements");
 	}

--- a/actions/GetAbsences.ts
+++ b/actions/GetAbsences.ts
@@ -151,7 +151,12 @@ export async function getAbsenceData(
 					if (bestMatch) {
 						const matchedCode = bestMatch.Code;
 						// Check for unjustified absences
-						if (!rowData.motif) {
+						// LISE fills motif with "Non excusé" instead of leaving it empty,
+						// so we must explicitly treat it as unjustified
+						const motifLower = (rowData.motif || "").trim().toLowerCase();
+						const isUnjustified =
+							!motifLower || motifLower === "non excusé" || motifLower === "non excuse";
+						if (isUnjustified) {
 							const hours = parseDurationToHours(rowData.duree);
 							if (!hoursMap[matchedCode]) {
 								hoursMap[matchedCode] = {

--- a/actions/GetGrades.ts
+++ b/actions/GetGrades.ts
@@ -267,7 +267,7 @@ export async function getGradeData(
 
 		// Telemetry & Logging
 		const duration = Date.now() - start;
-		posthog.capture({
+		posthog?.capture({
 			distinctId: user.username,
 			event: "scraper_performance",
 			properties: {
@@ -295,7 +295,7 @@ export async function getGradeData(
 			deleted_dupes: deletePromises.length, // This now includes removed grades
 		});
 	} catch (error) {
-		posthog.capture({
+		posthog?.capture({
 			distinctId: user.username || "unknown",
 			event: "scraper_error",
 			properties: { error: String(error) },
@@ -303,7 +303,7 @@ export async function getGradeData(
 		logger.error("Error fetching grades", { error: error });
 		return { errors: "Error fetching grades", success: false };
 	} finally {
-		await posthog.shutdown();
+		await posthog?.shutdown();
 	}
 
 	return { data: mappedDbGrades, success: true };

--- a/app/posthog-provider.tsx
+++ b/app/posthog-provider.tsx
@@ -5,7 +5,11 @@ import { PostHogProvider } from "posthog-js/react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { useEffect, Suspense } from "react";
 
-if (typeof window !== "undefined") {
+if (
+	typeof window !== "undefined" &&
+	process.env.NEXT_PUBLIC_POSTHOG_KEY &&
+	process.env.NEXT_PUBLIC_POSTHOG_HOST
+) {
 	posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
 		api_host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
 		person_profiles: "identified_only",
@@ -26,7 +30,7 @@ function PostHogPageView() {
 			if (searchParams && searchParams.toString()) {
 				url = url + `?${searchParams.toString()}`;
 			}
-			posthog.capture("$pageview", {
+			posthog?.capture("$pageview", {
 				$current_url: url,
 			});
 		}
@@ -36,6 +40,12 @@ function PostHogPageView() {
 }
 
 export function PHProvider({ children }: { children: React.ReactNode }) {
+	if (
+		!process.env.NEXT_PUBLIC_POSTHOG_KEY ||
+		!process.env.NEXT_PUBLIC_POSTHOG_HOST
+	) {
+		return <>{children}</>;
+	}
 	return (
 		<PostHogProvider client={posthog}>
 			<Suspense fallback={null}>
@@ -45,3 +55,4 @@ export function PHProvider({ children }: { children: React.ReactNode }) {
 		</PostHogProvider>
 	);
 }
+

--- a/components/AbsencesTable.tsx
+++ b/components/AbsencesTable.tsx
@@ -112,8 +112,8 @@ export function AbsencesTable({ session }: { session: any }) {
 					<Button
 						status="secondary"
 						onClick={() => {
-							if (posthog.has_opted_in_capturing()) {
-								posthog.capture("absences_stats_click");
+							if (posthog?.has_opted_in_capturing()) {
+								posthog?.capture("absences_stats_click");
 							}
 							setIsStatsModalOpen(true);
 						}}
@@ -127,8 +127,8 @@ export function AbsencesTable({ session }: { session: any }) {
 						status="primary"
 						onClick={() => {
 							refetch();
-							if (posthog.has_opted_in_capturing()) {
-								posthog.capture("absences_refresh");
+							if (posthog?.has_opted_in_capturing()) {
+								posthog?.capture("absences_refresh");
 							}
 						}}
 						disabled={isFetching}

--- a/components/ChangelogManager.tsx
+++ b/components/ChangelogManager.tsx
@@ -20,8 +20,8 @@ export default function ChangelogManager() {
 		if (lastSeenVersion !== CURRENT_VERSION) {
 			const timer = setTimeout(() => {
 				setIsOpen(true);
-				if (posthog.has_opted_in_capturing()) {
-					posthog.capture("changelog_auto_open", { version: CURRENT_VERSION });
+				if (posthog?.has_opted_in_capturing()) {
+					posthog?.capture("changelog_auto_open", { version: CURRENT_VERSION });
 				}
 			}, 1500);
 			return () => clearTimeout(timer);

--- a/components/GradeTable.tsx
+++ b/components/GradeTable.tsx
@@ -257,8 +257,8 @@ export function GradeTable({ session, gambling }: GradeTableProps) {
 			setGradeToReveal(grade);
 			setSelectedGrade(null);
 		} else {
-			if (posthog.has_opted_in_capturing()) {
-				posthog.capture("view_grade_detail_event", { grade_code: grade.code });
+			if (posthog?.has_opted_in_capturing()) {
+				posthog?.capture("view_grade_detail_event", { grade_code: grade.code });
 			}
 			setSelectedGrade(grade);
 			setGradeToReveal(null);
@@ -340,8 +340,8 @@ export function GradeTable({ session, gambling }: GradeTableProps) {
 						status="primary"
 						onClick={() => {
 							refetch();
-							if (posthog.has_opted_in_capturing())
-								posthog.capture("grades_refresh");
+							if (posthog?.has_opted_in_capturing())
+								posthog?.capture("grades_refresh");
 						}}
 						disabled={isFetching}
 						className="shrink-0 !px-3"

--- a/components/InstallBanner.tsx
+++ b/components/InstallBanner.tsx
@@ -22,8 +22,8 @@ export default function InstallAppBanner() {
     // Prompt the user to install the app
     alert("To install this app, tap the Share button and then 'Add to Home Screen'.");
     setIsIOS(false); // Hide the banner after prompting
-    if(posthog.has_opted_in_capturing()){
-      posthog.capture('install_to_home_event', {isIOS, isStandalone})
+    if(posthog?.has_opted_in_capturing()){
+      posthog?.capture('install_to_home_event', {isIOS, isStandalone})
     }
   }
 

--- a/components/LoginForm.tsx
+++ b/components/LoginForm.tsx
@@ -71,16 +71,16 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
 		localStorage.setItem("lise_id", username);
 		setLoading(true);
 
-		if (posthog.has_opted_in_capturing()) {
-			posthog.capture("login_attempt", { lise_id: username });
+		if (posthog?.has_opted_in_capturing()) {
+			posthog?.capture("login_attempt", { lise_id: username });
 		}
 
 		try {
 			// Call the signIn action
 			const state = await signIn(undefined, formData);
 			if (state?.success) {
-				if (posthog.has_opted_in_capturing()) {
-					posthog.capture("login_success", { lise_id: username });
+				if (posthog?.has_opted_in_capturing()) {
+					posthog?.capture("login_success", { lise_id: username });
 				}
 
 				if (onSuccess) {
@@ -89,8 +89,8 @@ export function LoginForm({ onSuccess }: LoginFormProps) {
 					router.push("/");
 				}
 			} else {
-				if (posthog.has_opted_in_capturing()) {
-					posthog.capture("login_failure", { lise_id: username });
+				if (posthog?.has_opted_in_capturing()) {
+					posthog?.capture("login_failure", { lise_id: username });
 				}
 				setErrors(state?.errors || "An error occurred during login.");
 				setLoading(false);

--- a/components/pwa/PwaInstallPrompt.tsx
+++ b/components/pwa/PwaInstallPrompt.tsx
@@ -45,8 +45,8 @@ export default function PwaInstallPrompt() {
 		if (/iphone|ipad|ipod/.test(userAgent)) {
 			setPlatform("ios");
 			setIsVisible(true);
-			if (posthog.has_opted_in_capturing()) {
-				posthog.capture("pwa_install_prompt_shown", { platform: "ios" });
+			if (posthog?.has_opted_in_capturing()) {
+				posthog?.capture("pwa_install_prompt_shown", { platform: "ios" });
 			}
 		} else if (/android/.test(userAgent)) {
 			setPlatform("android");
@@ -71,8 +71,8 @@ export default function PwaInstallPrompt() {
 				setPlatform("android"); // Ensure android is set if event fires
 				setIsVisible(true);
 
-				if (posthog.has_opted_in_capturing()) {
-					posthog.capture("pwa_install_prompt_shown", { platform: "android" });
+				if (posthog?.has_opted_in_capturing()) {
+					posthog?.capture("pwa_install_prompt_shown", { platform: "android" });
 				}
 			}
 		};
@@ -90,8 +90,8 @@ export default function PwaInstallPrompt() {
 	const handleDismiss = () => {
 		setIsVisible(false);
 		localStorage.setItem("pwa_install_dismissed", "true");
-		if (posthog.has_opted_in_capturing()) {
-			posthog.capture("pwa_install_prompt_dismissed", { platform });
+		if (posthog?.has_opted_in_capturing()) {
+			posthog?.capture("pwa_install_prompt_dismissed", { platform });
 		}
 	};
 
@@ -105,13 +105,13 @@ export default function PwaInstallPrompt() {
 		const { outcome } = await deferredPrompt.userChoice;
 
 		if (outcome === "accepted") {
-			if (posthog.has_opted_in_capturing()) {
-				posthog.capture("pwa_install_prompt_accepted", { platform: "android" });
+			if (posthog?.has_opted_in_capturing()) {
+				posthog?.capture("pwa_install_prompt_accepted", { platform: "android" });
 			}
 			setIsVisible(false);
 		} else {
-			if (posthog.has_opted_in_capturing()) {
-				posthog.capture("pwa_install_prompt_dismissed", {
+			if (posthog?.has_opted_in_capturing()) {
+				posthog?.capture("pwa_install_prompt_dismissed", {
 					platform: "android",
 					reason: "native_prompt_cancelled",
 				});

--- a/components/ui/CalendarEvent.tsx
+++ b/components/ui/CalendarEvent.tsx
@@ -78,8 +78,8 @@ const CalendarEventComponent = ({
 
 	useEffect(() => {
 		if (isActive && type == "RU") {
-			if (posthog.has_opted_in_capturing()) {
-				posthog.capture("RU_display_event", { tbk: tbk, date: startDate });
+			if (posthog?.has_opted_in_capturing()) {
+				posthog?.capture("RU_display_event", { tbk: tbk, date: startDate });
 			}
 		}
 	}, [isActive, posthog, tbk, startDate, type]);

--- a/components/ui/LoadingPlaceholder.tsx
+++ b/components/ui/LoadingPlaceholder.tsx
@@ -1,78 +1,84 @@
 export default function LoadingPlaceholder() {
     return (
         <div className="flex flex-col animate-pulse h-full w-full">
-        {/* Header Skeleton */}
-        <div className="sticky top-0 z-30 flex-none bg-backgroundPrimary shadow ring-opacity-5">
-            <div className="grid grid-cols-5 text-sm sm:hidden">
-            <div className="col-end-1 w-14" />
-            {Array.from({ length: 5 }).map((_, i) => (
-                <div
-                key={i}
-                className="flex flex-col items-center pt-1 pb-1 space-y-2"
-                >
-                <div className="h-3 w-8 rounded bg-calendarGridBorder" />
-                <div className="h-8 w-8 rounded-full bg-calendarGridBorder" />
+            {/* Header Skeleton */}
+            <div className="sticky top-0 z-30 flex-none bg-backgroundPrimary shadow ring-opacity-5">
+                <div className="grid grid-cols-5 text-sm sm:hidden">
+                    <div className="col-end-1 w-14" />
+                    {Array.from({ length: 5 }).map((_, i) => (
+                        <div
+                            key={i}
+                            className="flex flex-col items-center pt-1 pb-1 space-y-2"
+                        >
+                            <div className="h-3 w-8 rounded bg-calendarGridBorder" />
+                            <div className="h-8 w-8 rounded-full bg-calendarGridBorder" />
+                        </div>
+                    ))}
                 </div>
-            ))}
-            </div>
 
-            <div className="-mr-px hidden grid-cols-5 divide-x divide-calendarGridBorder border-r border-calendarGridBorder text-sm leading-6 sm:grid">
-            <div className="col-end-1 w-14" />
-            {Array.from({ length: 5 }).map((_, i) => (
-                <div
-                key={i}
-                className="flex items-center justify-center py-3"
-                >
-                <div className="h-5 w-16 rounded bg-calendarGridBorder" />
+                <div className="-mr-px hidden grid-cols-5 divide-x divide-calendarGridBorder border-r border-calendarGridBorder text-sm leading-6 sm:grid">
+                    <div className="col-end-1 w-14" />
+                    {Array.from({ length: 5 }).map((_, i) => (
+                        <div
+                            key={i}
+                            className="flex items-center justify-center py-3"
+                        >
+                            <div className="h-5 w-16 rounded bg-calendarGridBorder" />
+                        </div>
+                    ))}
                 </div>
-            ))}
-            </div>
-        </div>
-
-        {/* Body Skeleton */}
-        <div className="flex flex-auto">
-            {/* Time labels */}
-            <div className="sticky left-0 z-10 w-14 flex-none bg-backgroundPrimary ring-1 ring-calendarGridBorder">
-            <div className="flex flex-col space-y-6 py-4">
-                {Array.from({ length: 10 }).map((_, i) => (
-                <div key={i} className="h-3 w-8 rounded bg-calendarGridBorder mx-auto" />
-                ))}
-            </div>
             </div>
 
-            {/* Events grid */}
-            <div className="grid flex-auto grid-cols-1 grid-rows-1">
-            <div
-                className="col-start-1 col-end-2 row-start-1 grid divide-y divide-calendarGridBorder"
-                style={{ gridTemplateRows: "repeat(24, minmax(2rem, 1fr))" }}
-            >
-                {Array.from({ length: 24 }).map((_, i) => (
-                <div key={i} className="relative" />
-                ))}
-            </div>
+            {/* Body Skeleton */}
+            <div className="flex flex-auto">
+                {/* Time labels */}
+                <div className="sticky left-0 z-10 w-14 flex-none bg-backgroundPrimary ring-1 ring-calendarGridBorder">
+                    <div className="flex flex-col space-y-6 py-4">
+                        {Array.from({ length: 10 }).map((_, i) => (
+                            <div key={i} className="h-3 w-8 rounded bg-calendarGridBorder mx-auto" />
+                        ))}
+                    </div>
+                </div>
 
-            {/* Event placeholders */}
-            <ol
-                className="col-start-1 col-end-2 row-start-1 grid grid-cols-5"
-                style={{ gridTemplateRows: "repeat(144, minmax(0, 1fr)) auto" }}
-            >
-                {Array.from({ length: 9 }).map((_, i) => {
-                const col = i % 5;
-                const row = Math.floor(Math.random() * 100);
-                const span = Math.floor(Math.random() * 8) + 20;
-                return (
-                    <li
-                    key={i}
-                    className={`m-1 rounded-lg bg-calendarGridBorder col-start-${col + 1}`}
-                    style={{
-                        gridRow: `${row} / span ${span}`,
-                    }}
-                    />
-                );
-                })}
-            </ol>
+                {/* Events grid */}
+                <div className="grid flex-auto grid-cols-1 grid-rows-1">
+                    <div
+                        className="col-start-1 col-end-2 row-start-1 grid divide-y divide-calendarGridBorder"
+                        style={{ gridTemplateRows: "repeat(24, minmax(2rem, 1fr))" }}
+                    >
+                        {Array.from({ length: 24 }).map((_, i) => (
+                            <div key={i} className="relative" />
+                        ))}
+                    </div>
+
+                    {/* Event placeholders */}
+                    <ol
+                        className="col-start-1 col-end-2 row-start-1 grid grid-cols-5"
+                        style={{ gridTemplateRows: "repeat(144, minmax(0, 1fr)) auto" }}
+                    >
+                        {(() => {
+                            // Deterministic positions to avoid SSR hydration mismatch
+                            const positions = [
+                                { row: 10, span: 22 }, { row: 45, span: 24 }, { row: 80, span: 20 },
+                                { row: 15, span: 26 }, { row: 55, span: 21 }, { row: 90, span: 23 },
+                                { row: 20, span: 25 }, { row: 60, span: 22 }, { row: 35, span: 27 },
+                            ];
+                            return positions.map((pos, i) => {
+                                const col = i % 5;
+                                return (
+                                    <li
+                                        key={i}
+                                        className={`m-1 rounded-lg bg-calendarGridBorder col-start-${col + 1}`}
+                                        style={{
+                                            gridRow: `${pos.row} / span ${pos.span}`,
+                                        }}
+                                    />
+                                );
+                            });
+                        })()}
+                    </ol>
+                </div>
             </div>
         </div>
-        </div>
-  );
+    );
 }

--- a/components/ui/SettingsDialog.tsx
+++ b/components/ui/SettingsDialog.tsx
@@ -298,8 +298,8 @@ export default function SettingsDialog({
 				await unsubscribe();
 			} else {
 				const success = await subscribe();
-				if (success && posthog.has_opted_in_capturing()) {
-					posthog.capture("push_notifications_enabled", { class: userClass });
+				if (success && posthog?.has_opted_in_capturing()) {
+					posthog?.capture("push_notifications_enabled", { class: userClass });
 				}
 			}
 		} catch (e) {
@@ -569,8 +569,8 @@ export default function SettingsDialog({
 								target="_blank"
 								className="flex flex-col items-center justify-center p-3 bg-backgroundSecondary rounded-xl hover:bg-backgroundTertiary transition-colors text-textSecondary"
 								onClick={() =>
-									posthog.has_opted_in_capturing()
-										? posthog.capture("github_click_event")
+									posthog?.has_opted_in_capturing()
+										? posthog?.capture("github_click_event")
 										: ""
 								}
 							>
@@ -582,8 +582,8 @@ export default function SettingsDialog({
 								target="_blank"
 								className="flex flex-col items-center justify-center p-3 bg-backgroundSecondary rounded-xl hover:bg-backgroundTertiary transition-colors text-textSecondary"
 								onClick={() =>
-									posthog.has_opted_in_capturing()
-										? posthog.capture("wiki_click_event")
+									posthog?.has_opted_in_capturing()
+										? posthog?.capture("wiki_click_event")
 										: ""
 								}
 							>
@@ -594,8 +594,8 @@ export default function SettingsDialog({
 								href="mailto:louis.chabanon@gadz.org"
 								className="flex flex-col items-center justify-center p-3 bg-backgroundSecondary rounded-xl hover:bg-backgroundTertiary transition-colors text-textSecondary"
 								onClick={() =>
-									posthog.has_opted_in_capturing()
-										? posthog.capture("mail_click_event")
+									posthog?.has_opted_in_capturing()
+										? posthog?.capture("mail_click_event")
 										: ""
 								}
 							>

--- a/hooks/useGradeSimulation.ts
+++ b/hooks/useGradeSimulation.ts
@@ -147,8 +147,8 @@ export function useGradeSimulation(initialGrades: GradeType[]) {
 
 	const addSimulation = (sim: SimulatedGrade) => {
 		setSimulatedGrades((prev) => [...prev, sim]);
-		if (posthog.has_opted_in_capturing()) {
-			posthog.capture("simulation_created", {
+		if (posthog?.has_opted_in_capturing()) {
+			posthog?.capture("simulation_created", {
 				UE: sim.classCode,
 				grade: sim.grade,
 				coeff: sim.coeff,
@@ -158,8 +158,8 @@ export function useGradeSimulation(initialGrades: GradeType[]) {
 
 	const removeSimulation = (id: string) => {
 		setSimulatedGrades((prev) => prev.filter((s) => s.id !== id));
-		if (posthog.has_opted_in_capturing()) {
-			posthog.capture("simulation_removed", {
+		if (posthog?.has_opted_in_capturing()) {
+			posthog?.capture("simulation_removed", {
 				simulation_id: id,
 			});
 		}
@@ -177,8 +177,8 @@ export function useGradeSimulation(initialGrades: GradeType[]) {
 
 	const handleClassOverride = (code: string, newClass: string) => {
 		setClassOverrides((prev) => ({ ...prev, [code]: newClass }));
-		if (posthog.has_opted_in_capturing()) {
-			posthog.capture("UE_overridden", {
+		if (posthog?.has_opted_in_capturing()) {
+			posthog?.capture("UE_overridden", {
 				code: code,
 				new_UE: newClass,
 			});
@@ -191,8 +191,8 @@ export function useGradeSimulation(initialGrades: GradeType[]) {
 		delete newLocal[code];
 		setLocalCoeffs(newLocal);
 
-		if (posthog.has_opted_in_capturing()) {
-			posthog.capture("weight_voted", {
+		if (posthog?.has_opted_in_capturing()) {
+			posthog?.capture("weight_voted", {
 				code,
 				weight,
 			});

--- a/lib/otel.ts
+++ b/lib/otel.ts
@@ -5,6 +5,11 @@ import { resourceFromAttributes } from "@opentelemetry/resources";
 import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 
 export function initSDK() {
+	if (!process.env.NEXT_PUBLIC_POSTHOG_HOST || !process.env.NEXT_PUBLIC_POSTHOG_KEY) {
+		console.log("PostHog OTel Logger skipped: missing NEXT_PUBLIC_POSTHOG_HOST or NEXT_PUBLIC_POSTHOG_KEY");
+		return;
+	}
+
 	const sdk = new NodeSDK({
 		resource: resourceFromAttributes({
 			[ATTR_SERVICE_NAME]: "better-lise-service",

--- a/lib/posthog-server.ts
+++ b/lib/posthog-server.ts
@@ -1,6 +1,12 @@
 import { PostHog } from "posthog-node";
 
 export default function PostHogClient() {
+	if (
+		!process.env.NEXT_PUBLIC_POSTHOG_HOST ||
+		!process.env.NEXT_PUBLIC_POSTHOG_KEY
+	) {
+		return null;
+	}
 	const posthogClient = new PostHog(process.env.NEXT_PUBLIC_POSTHOG_KEY!, {
 		host: process.env.NEXT_PUBLIC_POSTHOG_HOST,
 		flushAt: 1,
@@ -8,3 +14,4 @@ export default function PostHogClient() {
 	});
 	return posthogClient;
 }
+


### PR DESCRIPTION
## What

Two bug fixes identified during a code analysis of the project:

### 1. Absences Résumé button always disabled (`actions/GetAbsences.ts`)

The Résumé button on `/absences` was always grayed out even when the user had absences. Root cause: the condition `!rowData.motif` checked if the motif field was empty, but LISE fills it with `"Non excusé"` for unjustified absences instead of leaving it empty. This caused `hoursMap` to always stay empty → `stats` always `[]` → button always disabled.

Fix: explicitly check for empty, `"non excusé"` and `"non excuse"` (without accent) as unjustified absences.

### 2. OTel/PostHog crash on startup when env vars are missing (`lib/otel.ts`)

`initSDK()` crashed at startup in environments where `NEXT_PUBLIC_POSTHOG_HOST` or `NEXT_PUBLIC_POSTHOG_KEY` are not set (e.g. local dev without PostHog configured). Added an early-return guard.

## Testing

Tested on the deployed app at better-lise.com — the Résumé button now correctly shows stats for unjustified absences.